### PR TITLE
Added carrier_id to Rate Response & Setup

### DIFF
--- a/src/Common/Setup.php
+++ b/src/Common/Setup.php
@@ -44,6 +44,13 @@ abstract class Setup
      *
      * @var string
      */
+    protected $carrier_id;
+
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
     protected $service;
 
     /**

--- a/src/Requests/Types/Setup.php
+++ b/src/Requests/Types/Setup.php
@@ -38,6 +38,7 @@ use ShipAndCoSDK\Requests\Types\Setup\CashOnDelivery;
 
 /**
  * @property-write string $carrier
+ * @property-write string $carrier_id
  * @property-write string $service
  * @property-write string $currency
  * @property-write DateTimeInterface $shipment_date

--- a/src/Responses/Types/Rate.php
+++ b/src/Responses/Types/Rate.php
@@ -33,6 +33,7 @@ use ShipAndCoSDK\Responses\Types\Rate\Surcharge;
 
 /**
  * @property-read string            $carrier
+ * @property-read string            $carrier_id
  * @property-read string            $service
  * @property-read string            $currency
  * @property-read float             $price
@@ -48,6 +49,13 @@ final class Rate
      * @var string
      */
     private $carrier;
+
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
+    private $carrier_id;
 
     /**
      * @JMS\Type("string")


### PR DESCRIPTION
Added carrier_id Setup used by Shipment Request to specify carrier configuration when handling multiple carrier accounts. As described in API documentation: https://developer.shipandco.com/en/#t-common_car

This PR:

- [x] Adds a new feature ...
- [ ] Covered by tests
- [ ] Fixes #nnnn
