### PR TITLE
Composer requires Doctrine Annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
+        "doctrine/annotations": "^1.14",
         "jms/serializer": "^3.9",
         "sanmai/json-serializer": "^0.1.1 || ^0.2.4",
         "sanmai/pipeline": "^5 || ^6",


### PR DESCRIPTION
JMS Serializer 3.30.0 plus requires update to property types or use of doctrine annotations package. See: https://github.com/schmittjoh/serializer/blob/master/UPGRADING.md

Without this, every request fails with type error, example:
```
You must define a type for ShipAndCoSDK\Responses\Types\Rate::$carrier.
```