### PR TITLE
Composer requires Doctrine Annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
+        "doctrine/annotations": "^1.14",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "jms/serializer": "^3.9",
         "sanmai/json-serializer": "^0.1.1 || ^0.2.4",


### PR DESCRIPTION
JMS Serializer 3.30.0 plus requires update to property types or use of doctrine annotations package. See: https://github.com/schmittjoh/serializer/blob/master/UPGRADING.md