### PR TITLE
API URL Update & Error Message fix

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -57,7 +57,7 @@ final class ClientBuilder implements LoggerAwareInterface
 
     private const DEFAULT_TIMEOUT = 60;
 
-    private const STANDARD_BASE_URL = 'https://app.shipandco.com';
+    private const STANDARD_BASE_URL = 'https://api.shipandco.com';
 
     private const PACKAGE_NAME = 'ShipAndCo-SDK';
     private const VERSION_INFO = '$Format:%h%d by %an +%ae$';

--- a/src/Requests/AddressesRequest.php
+++ b/src/Requests/AddressesRequest.php
@@ -39,6 +39,6 @@ final class AddressesRequest implements Request
     use RequestCore;
 
     private const METHOD = 'GET';
-    private const ADDRESS = '/api/v1/addresses';
+    private const ADDRESS = '/v1/addresses';
     private const RESPONSE = AddressesResponse::class;
 }

--- a/src/Requests/CarriersRequest.php
+++ b/src/Requests/CarriersRequest.php
@@ -39,6 +39,6 @@ final class CarriersRequest implements Request
     use RequestCore;
 
     private const METHOD = 'GET';
-    private const ADDRESS = '/api/v1/carriers';
+    private const ADDRESS = '/v1/carriers';
     private const RESPONSE = CarriersResponse::class;
 }

--- a/src/Requests/CreateShipmentRequest.php
+++ b/src/Requests/CreateShipmentRequest.php
@@ -45,6 +45,6 @@ final class CreateShipmentRequest implements JsonRequest
     use ShipmentFields;
 
     private const METHOD = 'POST';
-    private const ADDRESS = '/api/v1/shipments';
+    private const ADDRESS = '/v1/shipments';
     private const RESPONSE = ShipmentResponse::class;
 }

--- a/src/Requests/RatesRequest.php
+++ b/src/Requests/RatesRequest.php
@@ -43,6 +43,6 @@ final class RatesRequest implements JsonRequest
     use ShipmentFields;
 
     private const METHOD = 'POST';
-    private const ADDRESS = '/api/v1/rates';
+    private const ADDRESS = '/v1/rates';
     private const RESPONSE = RatesResponse::class;
 }

--- a/src/Requests/WarehousesRequest.php
+++ b/src/Requests/WarehousesRequest.php
@@ -39,6 +39,6 @@ final class WarehousesRequest implements Request
     use RequestCore;
 
     private const METHOD = 'GET';
-    private const ADDRESS = '/api/v1/addresses';
+    private const ADDRESS = '/v1/addresses';
     private const RESPONSE = AddressesResponse::class;
 }

--- a/src/Responses/Bad/ErrorResponse/Detail.php
+++ b/src/Responses/Bad/ErrorResponse/Detail.php
@@ -88,6 +88,6 @@ final class Detail implements HasErrorCode
 
     public function getMessage(): string
     {
-        return $this->message;
+        return $this->message ?? '';
     }
 }


### PR DESCRIPTION
- API URL update, as notified by email by Ship&Co on 23/July/2024. Must be updated by Friday 6/Sep/2024.
- Minor update for avoiding a crash when handling errors without a message

This PR:

- [x] Adds a new feature ...
- [ ] Covered by tests
- [ ] Fixes #nnnn
