### PR TITLE
Added latest API Setup Options (#20)

### DIFF
--- a/src/Common/Setup.php
+++ b/src/Common/Setup.php
@@ -121,6 +121,13 @@ abstract class Setup
      *
      * @var string
      */
+    protected $cool_options;
+
+    /**
+     * @JMS\Type("int")
+     *
+     * @var int
+     */
     protected $pack_size;
 
     /**
@@ -143,6 +150,27 @@ abstract class Setup
      * @var int
      */
     protected $print_start_location;
+
+    /**
+     * @JMS\Type("float")
+     *
+     * @var float
+     */
+    protected $shipping_fee;
+
+    /**
+     * @JMS\Type("bool")
+     *
+     * @var bool
+     */
+    protected $security_service;
+
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
+    protected $consignee_tax_id;
 
     /**
      * @JMS\Type("bool")

--- a/src/Requests/Types/Setup.php
+++ b/src/Requests/Types/Setup.php
@@ -49,12 +49,16 @@ use ShipAndCoSDK\Requests\Types\Setup\CashOnDelivery;
  * @property-write string $delivery_note
  * @property-write float|int $discount
  * @property-write bool $signature
+ * @property-write string $cool_options
  * @property-read Care $care
- * @property-write string $pack_size
+ * @property-write int $pack_size
  * @property-write int $pack_amount
  * @property-read CashOnDelivery $cash_on_delivery
  * @property-write bool $return_label
  * @property-write int $print_start_location
+ * @property-write float $shipping_fee
+ * @property-write bool $security_service
+ * @property-write string $consignee_tax_id
  * @property-write bool $test
  */
 final class Setup extends CommonSetup implements ReadableRequestProperty

--- a/src/Responses/Types/Setup.php
+++ b/src/Responses/Types/Setup.php
@@ -37,8 +37,10 @@ use ShipAndCoSDK\Responses\Types\Setup\CashOnDelivery;
 
 /**
  * @property-read string $carrier
+ * @property-read string $carrier_id
  * @property-read string $service
  * @property-read string $currency
+ * @property-read DateTimeInterface $shipment_date
  * @property-read DateTimeInterface $date
  * @property-read string $time
  * @property-read float|int $insurance
@@ -46,10 +48,16 @@ use ShipAndCoSDK\Responses\Types\Setup\CashOnDelivery;
  * @property-read string $delivery_note
  * @property-read float|int $discount
  * @property-read bool $signature
+ * @property-read string $cool_options
  * @property-read Care $care
- * @property-read string $pack_size
+ * @property-read int $pack_size
  * @property-read int $pack_amount
  * @property-read CashOnDelivery $cash_on_delivery
+ * @property-read bool $return_label
+ * @property-read int $print_start_location
+ * @property-read float $shipping_fee
+ * @property-read bool $security_service
+ * @property-read string $consignee_tax_id
  * @property-read bool $test
  */
 final class Setup extends CommonSetup

--- a/tests/Deserialization/ShipmentResponseTest.php
+++ b/tests/Deserialization/ShipmentResponseTest.php
@@ -89,9 +89,11 @@ class ShipmentResponseTest extends TestCase
                 'ref_number'           => '',
                 'delivery_note'        => '',
                 'discount'             => 0.0,
-                'pack_size'            => '0',
+                'cool_options'         => 'regular',
+                'pack_size'            => 0,
                 'pack_amount'          => 3,
                 'print_start_location' => 1,
+                'shipping_fee'         => 0.0,
                 'test'                 => true,
                 'care'                 => [
                     'fragile'        => false,
@@ -259,7 +261,7 @@ class ShipmentResponseTest extends TestCase
                 'ref_number'    => '',
                 'delivery_note' => '',
                 'discount'      => 0.0,
-                'pack_size'     => '0',
+                'pack_size'     => 0,
                 'pack_amount'   => 3,
                 'test'          => true,
                 'care'          => [

--- a/tests/Fixtures/requests/CreateShipmentRequest_example.json
+++ b/tests/Fixtures/requests/CreateShipmentRequest_example.json
@@ -55,7 +55,7 @@
         "ref_number": "",
         "delivery_note": "",
         "signature": false,
-        "pack_size": "0",
+        "pack_size": 0,
         "pack_amount": 3,
         "return_label": false,
         "print_start_location": 1,


### PR DESCRIPTION
* Ship&Co Latest Shipment Setup Options:
* Cool Options
* Shipping Fee
* Security Service
* Consignee Tax ID

See: https://developer.shipandco.com/en/#t-common_car

* Ship&Co API Pack Size compatibility Fix

Pack Size changed from string to int to align to API documentation

Advised by Ship&co email as a mandatory change as of July 3rd, 2025.

* Fix: Pack Size changed from string to int to align to API documentation
